### PR TITLE
Fix broken package url and change base image to debian stable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![](https://images.microbadger.com/badges/image/dailyhotel/maxscale.svg)](https://microbadger.com/images/dailyhotel/maxscale "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/license/dailyhotel/maxscale.svg)](https://microbadger.com/images/dailyhotel/maxscale "Get your own license badge on microbadger.com")
+
 # docker-maxscale
 
 This project is a Docker image for MaxScale. 
@@ -47,5 +50,5 @@ Contributions are welcome.
 
 ## License
 
-Copyright 2015 Andrea Sosso
+Copyright 2015 (주)데일리
 Licensed under the MIT License

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-maxscale-docker
-===============
+# docker-maxscale
 
-This project is a Docker container for MaxScale. 
-
-[![](https://images.microbadger.com/badges/image/andromedarabbit/maxscale.svg)](https://microbadger.com/images/andromedarabbit/maxscale "Get your own image badge on microbadger.com")
-[![](https://images.microbadger.com/badges/license/andromedarabbit/maxscale.svg)](https://microbadger.com/images/andromedarabbit/maxscale "Get your own license badge on microbadger.com")
-
+This project is a Docker image for MaxScale. 
 
 Base [docker image](http://www.docker.io) to run a [MaxScale](https://mariadb.com/products/mariadb-maxscale) server
 
@@ -13,12 +8,13 @@ Base [docker image](http://www.docker.io) to run a [MaxScale](https://mariadb.co
     It’s pluggable architecture is designed to increase flexibility and aid customization. Built upon a lightweight, high-speed networking core designed to facilitate throughput.
     MariaDB MaxScale runs between the client application and the database cluster offering connection and statement-based load balancing. 
     MariaDB MaxScale allows scaling of an organization's database infrastructure while keeping the needs of DBAs, Developers and Data Architects in mind.
+This project is a Docker container for MaxScale.
 
 ## Getting the container
 
 The container is very small and available on the Docker Index:
 
-    docker pull andromedarabbit/maxscale
+    docker pull dailyhotel/maxscale
 
 ## Using the container
 
@@ -26,13 +22,13 @@ Just trying out MaxScale.
 
 If you just want to run a single instance of MaxScale server to try out its functionality:
 
-    docker run -d andromedarabbit/maxscale
+    docker run -d dailyhotel/maxscale
 
 ## Build the container
 
-To create the image `andromedarabbit/maxscale`, execute the following command on the maxscale-docker folder:
+To create the image `dailyhotel/maxscale`, execute the following command on the maxscale-docker folder:
 
-    docker build -t andromedarabbit/maxscale .
+    docker build -t dailyhotel/maxscale .
 
 ## Thanks
 

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,16 +1,27 @@
-FROM centos:7
-MAINTAINER Jaehoon Choi <plaintext@andromedarabbit.net>
+FROM debian:stable
 
-ENV MAXSCALE_URL https://downloads.mariadb.com/MaxScale/2.1.5/rhel/7/x86_64/maxscale-2.1.5-1.rhel.7.x86_64.rpm
-ONBUILD ENV MAXSCALE_URL $MAXSCALE_URL
+LABEL maintainer="Jaehoon Choi <plaintext@andromedarabbit.net>"
 
-ONBUILD RUN rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB \
-    && yum -y install https://downloads.mariadb.com/enterprise/yzsw-dthq/generate/10.0/mariadb-enterprise-repository.rpm \
-    && yum -y update \
-    && yum deplist maxscale | grep provider | awk '{print $2}' | sort | uniq | grep -v maxscale | sed ':a;N;$!ba;s/\n/ /g' | xargs yum -y install \
-    && rpm -Uvh $MAXSCALE_URL \
-    && yum clean all \
-    && rm -rf /tmp/*
+ARG DEBIAN_FRONTEND
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG MAXSCALE_URL
+ONBUILD ENV MAXSCALE_URL=http://downloads.mariadb.com/enterprise/4d7m-n51s/mariadb-maxscale/latest/debian/dists/stretch/main/binary-amd64/maxscale-2.1.9-1.debian.stretch.x86_64.deb
+
+# Setup base packages.
+ONBUILD RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends apt-utils \
+    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends libsqlite3-dev \
+    && apt-get install -y --no-install-recommends libssl1.1 \
+    && apt-get purge -y --auto-remove \
+                     -o APT::AutoRemove::RecommendsImportant=false
+
+ONBUILD RUN curl -o maxscale.deb ${MAXSCALE_URL}
+
+ONBUILD RUN dpkg -i maxscale.deb \
+    && rm maxscale.deb
 
 # Move configuration file in directory for exports
 ONBUILD RUN mkdir -p /etc/maxscale.d \
@@ -19,6 +30,7 @@ ONBUILD RUN mkdir -p /etc/maxscale.d \
 
 # VOLUME for custom configuration
 VOLUME ["/etc/maxscale.d"]
+
 
 # EXPOSE the MaxScale default ports
 


### PR DESCRIPTION
- Update broken MaxScale package url.
- Update MaxScale version 2.1.5 to 2.1.9
- Change base image from CentOS 7 to Debian stable.